### PR TITLE
French URLs

### DIFF
--- a/nemo_text_processing/text_normalization/fr/data/electronic/domain.tsv
+++ b/nemo_text_processing/text_normalization/fr/data/electronic/domain.tsv
@@ -1,0 +1,12 @@
+.com	point com
+.org	point org
+.gov	point gov
+.uk	point UK
+.fr	point FR
+.net	point net
+.br	point BR
+.in	point IN
+.ru	point RU
+.de	point DE
+.it	point IT
+.jpg	point jpeg

--- a/nemo_text_processing/text_normalization/fr/data/electronic/symbol.tsv
+++ b/nemo_text_processing/text_normalization/fr/data/electronic/symbol.tsv
@@ -1,3 +1,20 @@
 .	point
 :	deux points
-/ slash
+/	slash
+-	tiret
+_	tiret bas
+!	point d'exclamation
+#	dièse
+$	dollar
+%	pour cent
+&	esperluette
+'	apostrophe
+*	astérisque
++	plus
+=	égal
+?	point d'interrogation
+^	accent circumflex
+`	accent grave
+|	barre verticale
+~	tilde
+,	virgule

--- a/nemo_text_processing/text_normalization/fr/data/electronic/symbol.tsv
+++ b/nemo_text_processing/text_normalization/fr/data/electronic/symbol.tsv
@@ -1,0 +1,3 @@
+.	point
+:	deux points
+/ slash

--- a/nemo_text_processing/text_normalization/fr/data/electronic/words.tsv
+++ b/nemo_text_processing/text_normalization/fr/data/electronic/words.tsv
@@ -1,0 +1,16 @@
+drive
+sim
+early
+access
+program
+rtx	RTX
+developer
+basepod	BASEPOD
+cuda	CUDA
+cv
+enterprise
+services
+nvidia	NVIDIA
+dgx	DGX
+pro
+help

--- a/nemo_text_processing/text_normalization/fr/taggers/electronic.py
+++ b/nemo_text_processing/text_normalization/fr/taggers/electronic.py
@@ -1,0 +1,123 @@
+# Copyright (c) 2021, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+import pynini
+from pynini.lib import pynutil
+
+from nemo_text_processing.text_normalization.fr.utils import get_abs_path
+from nemo_text_processing.text_normalization.en.graph_utils import (
+    MIN_NEG_WEIGHT,
+    NEMO_ALPHA,
+    NEMO_DIGIT,
+    NEMO_NOT_SPACE,
+    NEMO_SIGMA,
+    NEMO_UPPER,
+    TO_UPPER,
+    GraphFst,
+    insert_space
+)
+
+
+class ElectronicFst(GraphFst):
+    """
+    Finite state transducer for classifying electronic: as URLs, email addresses, etc.
+        e.g. cdf1@abc.edu -> tokens { electronic { username: "cdf1" domain: "abc.edu" } }
+
+    Args:
+        cardinal: CardinalFst
+        deterministic: if True will provide a single transduction option,
+            for False multiple transduction are generated (used for audio-based normalization)
+    """
+
+    def __init__(self, cardinal: GraphFst, deterministic: bool = True):
+        super().__init__(name="electronic", kind="classify", deterministic=deterministic)
+
+        if deterministic:
+            numbers = NEMO_DIGIT
+        else:
+            numbers = pynutil.insert(" ") + cardinal.long_numbers + pynutil.insert(" ")
+
+        accepted_symbols = pynini.project(pynini.string_file(get_abs_path("data/electronic/symbol.tsv")), "input")
+        accepted_common_domains = pynini.project(
+            pynini.string_file(get_abs_path("data/electronic/domain.tsv")), "input"
+        )
+
+        dict_words = pynutil.add_weight(pynini.string_file(get_abs_path("data/electronic/words.tsv")), MIN_NEG_WEIGHT)
+
+        dict_words_without_delimiter = dict_words + pynini.closure(
+            pynutil.add_weight(pynutil.insert(" ") + dict_words, MIN_NEG_WEIGHT), 1
+        )
+        dict_words_graph = dict_words_without_delimiter | dict_words
+
+        all_accepted_symbols_start = (
+            dict_words_graph | pynini.closure(TO_UPPER) | pynini.closure(NEMO_UPPER) | accepted_symbols
+        ).optimize()
+
+        all_accepted_symbols_end = (
+            dict_words_graph | numbers | pynini.closure(TO_UPPER) | pynini.closure(NEMO_UPPER) | accepted_symbols
+        ).optimize()
+
+        graph_symbols = pynini.string_file(get_abs_path("data/electronic/symbol.tsv")).optimize()
+        username = (NEMO_ALPHA | dict_words_graph) + pynini.closure(
+            NEMO_ALPHA | numbers | accepted_symbols | dict_words_graph
+        )
+
+        username = pynutil.insert("username: \"") + username + pynutil.insert("\"") + pynini.cross('@', ' ')
+
+        domain_graph = all_accepted_symbols_start + pynini.closure(
+            all_accepted_symbols_end | pynutil.add_weight(accepted_common_domains, MIN_NEG_WEIGHT)
+        )
+
+        protocol_symbols = pynini.closure((graph_symbols | pynini.cross(":", "colon")) + pynutil.insert(" "))
+        protocol_start = (pynini.cross("https", "HTTPS ") | pynini.cross("http", "HTTP ")) + (
+            pynini.accep("://") @ protocol_symbols
+        )
+        protocol_file_start = pynini.accep("file") + insert_space + (pynini.accep(":///") @ protocol_symbols)
+
+        protocol_end = pynutil.add_weight(pynini.cross("www", "double-vé double-vé double-vé ") + pynini.accep(".") @ protocol_symbols, -1000)
+        protocol = protocol_file_start | protocol_start | protocol_end | (protocol_start + protocol_end)
+
+        domain_graph_with_class_tags = (
+            pynutil.insert("domain: \"")
+            + pynini.compose(
+                NEMO_ALPHA + pynini.closure(NEMO_NOT_SPACE) + (NEMO_ALPHA | NEMO_DIGIT | pynini.accep("/")),
+                domain_graph,
+            ).optimize()
+            + pynutil.insert("\"")
+        )
+
+        protocol = pynutil.insert("protocol: \"") + pynutil.add_weight(protocol, MIN_NEG_WEIGHT) + pynutil.insert("\"")
+        # email
+        graph = pynini.compose(
+            NEMO_SIGMA + pynini.accep("@") + NEMO_SIGMA + pynini.accep(".") + NEMO_SIGMA,
+            username + domain_graph_with_class_tags,
+        )
+
+        # abc.com, abc.com/123-sm
+        # when only domain, make sure it starts and end with NEMO_ALPHA
+        graph |= (
+            pynutil.insert("domain: \"")
+            + pynini.compose(
+                NEMO_ALPHA + pynini.closure(NEMO_NOT_SPACE) + accepted_common_domains + pynini.closure(NEMO_NOT_SPACE),
+                domain_graph,
+            ).optimize()
+            + pynutil.insert("\"")
+        )
+        # www.abc.com/sdafsdf, or https://www.abc.com/asdfad or www.abc.abc/asdfad
+        graph |= protocol + pynutil.insert(" ") + domain_graph_with_class_tags
+
+        final_graph = self.add_tokens(graph)
+
+        self.fst = final_graph.optimize()

--- a/nemo_text_processing/text_normalization/fr/taggers/electronic.py
+++ b/nemo_text_processing/text_normalization/fr/taggers/electronic.py
@@ -80,7 +80,7 @@ class ElectronicFst(GraphFst):
             all_accepted_symbols_end | pynutil.add_weight(accepted_common_domains, MIN_NEG_WEIGHT)
         )
 
-        protocol_symbols = pynini.closure((graph_symbols | pynini.cross(":", "colon")) + pynutil.insert(" "))
+        protocol_symbols = pynini.closure((graph_symbols | pynini.cross(":", "deux points")) + pynutil.insert(" "))
         protocol_start = (pynini.cross("https", "HTTPS ") | pynini.cross("http", "HTTP ")) + (
             pynini.accep("://") @ protocol_symbols
         )

--- a/nemo_text_processing/text_normalization/fr/taggers/tokenize_and_classify.py
+++ b/nemo_text_processing/text_normalization/fr/taggers/tokenize_and_classify.py
@@ -25,6 +25,7 @@ from nemo_text_processing.text_normalization.en.graph_utils import (
     generator_main,
 )
 from nemo_text_processing.text_normalization.en.taggers.punctuation import PunctuationFst
+from nemo_text_processing.text_normalization.fr.taggers.electronic import ElectronicFst
 from nemo_text_processing.text_normalization.fr.taggers.cardinal import CardinalFst
 from nemo_text_processing.text_normalization.fr.taggers.decimals import DecimalFst
 from nemo_text_processing.text_normalization.fr.taggers.fraction import FractionFst
@@ -81,7 +82,7 @@ class ClassifyFst(GraphFst):
             decimal_graph = self.decimal.fst
 
             time_graph = TimeFst(cardinal=self.cardinal, deterministic=deterministic).fst
-
+            electronic_graph = ElectronicFst(cardinal=self.cardinal, deterministic=deterministic).fst
             self.fraction = FractionFst(cardinal=self.cardinal, ordinal=self.ordinal, deterministic=deterministic)
             fraction_graph = self.fraction.fst
             word_graph = WordFst(deterministic=deterministic).fst
@@ -96,6 +97,7 @@ class ClassifyFst(GraphFst):
                 | pynutil.add_weight(cardinal_graph, 1.1)
                 | pynutil.add_weight(ordinal_graph, 1.1)
                 | pynutil.add_weight(decimal_graph, 1.1)
+                | pynutil.add_weight(electronic_graph, 1.1)
                 | pynutil.add_weight(word_graph, 200)
             )
 

--- a/nemo_text_processing/text_normalization/fr/verbalizers/electronic.py
+++ b/nemo_text_processing/text_normalization/fr/verbalizers/electronic.py
@@ -1,0 +1,119 @@
+# Copyright (c) 2021, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import pynini
+from pynini.examples import plurals
+from pynini.lib import pynutil
+
+from nemo_text_processing.text_normalization.en.graph_utils import (
+    MIN_NEG_WEIGHT,
+    NEMO_ALPHA,
+    NEMO_CHAR,
+    NEMO_LOWER,
+    NEMO_NOT_QUOTE,
+    NEMO_SIGMA,
+    NEMO_SPACE,
+    TO_LOWER,
+    GraphFst,
+    delete_extra_space,
+    delete_space,
+    insert_space,
+)
+from nemo_text_processing.text_normalization.fr.utils import get_abs_path
+
+
+class ElectronicFst(GraphFst):
+    """
+    Finite state transducer for verbalizing electronic
+        e.g. tokens { electronic { username: "cdf1" domain: "abc.edu" } } -> c d f one at a b c dot e d u
+
+    Args:
+        deterministic: if True will provide a single transduction option,
+        for False multiple transduction are generated (used for audio-based normalization)
+    """
+
+    def __init__(self, deterministic: bool = True):
+        super().__init__(name="electronic", kind="verbalize", deterministic=deterministic)
+        graph_digit_no_zero = pynini.invert(pynini.string_file(get_abs_path("data/numbers/digit.tsv"))).optimize()
+        graph_zero = pynini.cross("0", "zéro")
+        long_numbers = pynutil.add_weight(graph_digit_no_zero + pynini.cross("000", " thousand"), MIN_NEG_WEIGHT)
+
+        graph_digit = graph_digit_no_zero | graph_zero
+        graph_symbols = pynini.string_file(get_abs_path("data/electronic/symbol.tsv")).optimize()
+
+        NEMO_NOT_BRACKET = pynini.difference(NEMO_CHAR, pynini.union("{", "}")).optimize()
+        dict_words = pynini.project(pynini.string_file(get_abs_path("data/electronic/words.tsv")), "output")
+        default_chars_symbols = pynini.cdrewrite(
+            pynutil.insert(" ") + (graph_symbols | graph_digit | long_numbers) + pynutil.insert(" "),
+            "",
+            "",
+            NEMO_SIGMA,
+        )
+        default_chars_symbols = pynini.compose(
+            pynini.closure(NEMO_NOT_BRACKET), default_chars_symbols.optimize()
+        ).optimize()
+
+        # this is far cases when user name was split by dictionary words, i.e. "sevicepart@ab.com" -> "service part"
+        space_separated_dict_words = pynutil.add_weight(
+            NEMO_ALPHA
+            + pynini.closure(NEMO_ALPHA | NEMO_SPACE)
+            + NEMO_SPACE
+            + pynini.closure(NEMO_ALPHA | NEMO_SPACE),
+            MIN_NEG_WEIGHT,
+        )
+
+        user_name = (
+            pynutil.delete("username:")
+            + delete_space
+            + pynutil.delete("\"")
+            + (default_chars_symbols | space_separated_dict_words).optimize()
+            + pynutil.delete("\"")
+        )
+
+        domain_common = pynini.string_file(get_abs_path("data/electronic/domain.tsv"))
+
+        # this will be used for a safe fallback
+        domain_all = pynini.compose(
+            default_chars_symbols,
+            pynini.closure(TO_LOWER | NEMO_LOWER | NEMO_SPACE | pynutil.add_weight(dict_words, MIN_NEG_WEIGHT)),
+        )
+
+        domain = (
+            domain_all
+            + insert_space
+            + plurals._priority_union(
+                domain_common, pynutil.add_weight(pynini.cross(".", "point"), weight=0.0001), NEMO_SIGMA
+            )
+            + pynini.closure(insert_space + default_chars_symbols, 0, 1)
+        )
+
+        domain = (
+            pynutil.delete("domain:")
+            + delete_space
+            + pynutil.delete("\"")
+            + (domain | pynutil.add_weight(domain_all, weight=100)).optimize()
+            + delete_space
+            + pynutil.delete("\"")
+        ).optimize()
+
+        protocol = pynutil.delete("protocol: \"") + pynini.closure(NEMO_NOT_QUOTE, 1) + pynutil.delete("\"")
+        graph = (
+            pynini.closure(protocol + delete_space, 0, 1)
+            + pynini.closure(user_name + delete_space + pynutil.insert(" arobas ") + delete_space, 0, 1)
+            + domain
+            + delete_space
+        ).optimize() @ pynini.cdrewrite(delete_extra_space, "", "", NEMO_SIGMA)
+
+        delete_tokens = self.delete_tokens(graph)
+        self.fst = delete_tokens.optimize()

--- a/nemo_text_processing/text_normalization/fr/verbalizers/electronic.py
+++ b/nemo_text_processing/text_normalization/fr/verbalizers/electronic.py
@@ -45,9 +45,9 @@ class ElectronicFst(GraphFst):
 
     def __init__(self, deterministic: bool = True):
         super().__init__(name="electronic", kind="verbalize", deterministic=deterministic)
-        graph_digit_no_zero = pynini.invert(pynini.string_file(get_abs_path("data/numbers/digit.tsv"))).optimize()
+        graph_digit_no_zero = pynini.string_file(get_abs_path("data/numbers/digit.tsv")).optimize()
         graph_zero = pynini.cross("0", "zéro")
-        long_numbers = pynutil.add_weight(graph_digit_no_zero + pynini.cross("000", " thousand"), MIN_NEG_WEIGHT)
+        long_numbers = pynutil.add_weight(graph_digit_no_zero + pynini.cross("000", " mille"), MIN_NEG_WEIGHT)
 
         graph_digit = graph_digit_no_zero | graph_zero
         graph_symbols = pynini.string_file(get_abs_path("data/electronic/symbol.tsv")).optimize()

--- a/nemo_text_processing/text_normalization/fr/verbalizers/verbalize.py
+++ b/nemo_text_processing/text_normalization/fr/verbalizers/verbalize.py
@@ -18,6 +18,7 @@ from nemo_text_processing.text_normalization.fr.verbalizers.cardinal import Card
 from nemo_text_processing.text_normalization.fr.verbalizers.decimals import DecimalFst
 from nemo_text_processing.text_normalization.fr.verbalizers.fraction import FractionFst
 from nemo_text_processing.text_normalization.fr.verbalizers.ordinal import OrdinalFst
+from nemo_text_processing.text_normalization.fr.verbalizers.electronic import ElectronicFst
 
 
 class VerbalizeFst(GraphFst):
@@ -40,10 +41,12 @@ class VerbalizeFst(GraphFst):
         decimal_graph = decimal.fst
         time = TimeFst(deterministic=deterministic)
         time_graph = time.fst
+        electronic = ElectronicFst(deterministic=deterministic)
+        electronic_graph = electronic.fst
         fraction = FractionFst(ordinal=ordinal, deterministic=deterministic)
         fraction_graph = fraction.fst
         whitelist_graph = WhiteListFst(deterministic=deterministic).fst
 
         
-        graph = cardinal_graph | time_graph | decimal_graph | ordinal_graph | fraction_graph | whitelist_graph
+        graph = cardinal_graph | time_graph | electronic_graph | decimal_graph | ordinal_graph | fraction_graph | whitelist_graph
         self.fst = graph

--- a/tests/nemo_text_processing/fr/data_text_normalization/test_cases_electronic.txt
+++ b/tests/nemo_text_processing/fr/data_text_normalization/test_cases_electronic.txt
@@ -1,0 +1,40 @@
+a.bc@gmail.com~a point bc arobas gmail point com
+a@hotmail.de~a arobas hotmail point de
+a@hotmail.fr~a arobas hotmail point fr
+a@hotmail.it~a arobas hotmail point it
+a@aol.it~a arobas aol point it
+a@msn.it~a arobas msn point it
+cdf@abc.edu~cdf arobas abc point edu
+abc@gmail.abc~abc arobas gmail point abc
+abc@abc.com~abc arobas abc point com
+asdf123@abc.com~asdf un deux trois arobas abc point com
+a1b2@abc.com~a un b deux arobas abc point com
+ab3.sdd.3@gmail.com~ab trois point sdd point trois arobas gmail point com
+email is abc1@gmail.com~l'email est abc un arobas gmail point com
+abs@nvidia.com~abs arobas nvidia point com
+email is a-1.b3_c&-d@gma4i-l.com test~l'email est a trait d'union un point b trois underscore c esperluette trait d'union d arobas gma quatre i trait d'union l point com test
+nvidia.com~nvidia point com
+test.com~test point com
+test.abc~test point abc
+http://www.ourdailynews.com.sm~HTTP deux points slash slash double-vé double-vé double-vé point ourdailynews point com point sm
+https://www.ourdailynews.com.sm~HTTPS deux points slash slash double-vé double-vé double-vé point ourdailynews point com point sm
+www.ourdailynews.com.sm~double-vé double-vé double-vé point ourdailynews point com point sm
+www.ourdailynews.com/123-sm~double-vé double-vé double-vé point ourdailynews point com slash un deux trois trait d'union sm
+sdf@gmail.com.sm~sdf arobas gmail point com point sm
+sdf@gmail.com/123-sm~sdf arobas gmail point com slash un deux trois trait d'union sm
+sdf@gmail.abc/123-sm~sdf arobas gmail point abc slash un deux trois trait d'union sm
+sdf@gmail.abc/123456-sm~sdf arobas gmail point abc slash un deux trois quatre cinq six trait d'union sm
+ourdailynews.com/12-sm~ourdailynews point com slash un deux trait d'union sm
+ourdailynews.abc~ourdailynews point abc
+file:///c/code/NeMo/docs/build/html/processing/intro.html~file trois points slash slash slash c slash code slash nemo slash docs slash build slash html slash processing slash intro point html
+file:///photos/image.jpg~file trois points slash slash slash photos slash image point jpg
+electronic test.com and test2.uk~electronic test point com et test deux point uk
+https://developer.nvidia.com/drive-sim-early-access-program~HTTPS deux points slash slash developer point nvidia point com slash drive trait d'union sim trait d'union early trait d'union access trait d'union program
+https://developer.nvidia.com/cv-cuda/early-access~HTTPS deux points slash slash developer point nvidia point com slash cv trait d'union cuda slash early trait d'union access
+https://www.nvidia.com/dgx-basepod~HTTPS deux points slash slash double-vé double-vé double-vé point nvidia point com slash DGX trait d'union basepod
+https://www.nvidia.com/dgx-basepod.sm/3~HTTPS deux points slash slash double-vé double-vé double-vé point nvidia point com slash DGX trait d'union basepod point sm slash trois
+http://www.nvidia.com/rtx-6000~HTTP deux points slash slash double-vé double-vé double-vé point nvidia point com slash RTX trait d'union six mille
+rtxprohelp@exchange.nvidia.com~RTX pro help arobas exchange point nvidia point com
+enterpriseservices@nvidia.com~enterprise services arobas nvidia point com
+enterprise-services@nvidia.com~enterprise trait d'union services arobas nvidia point com
+https://www.nvidia.com/dgx-basepod/~HTTPS deux points slash slash double-vé double-vé double-vé point nvidia point com slash DGX trait d'union basepod slash

--- a/tests/nemo_text_processing/fr/data_text_normalization/test_cases_electronic.txt
+++ b/tests/nemo_text_processing/fr/data_text_normalization/test_cases_electronic.txt
@@ -1,40 +1,40 @@
 a.bc@gmail.com~a point bc arobas gmail point com
-a@hotmail.de~a arobas hotmail point de
-a@hotmail.fr~a arobas hotmail point fr
-a@hotmail.it~a arobas hotmail point it
-a@aol.it~a arobas aol point it
-a@msn.it~a arobas msn point it
-cdf@abc.edu~cdf arobas abc point edu
-abc@gmail.abc~abc arobas gmail point abc
+a@hotmail.de~a arobas hotmail point DE
+a@hotmail.fr~a arobas hotmail point FR
+a@hotmail.it~a arobas hotmail point IT
+a@aol.it~a arobas aol point IT
+a@msn.it~a arobas msn point IT
+cdf@abc.edu~cdf arobas abc point EDU
+abc@gmail.abc~abc arobas gmail point ABC
 abc@abc.com~abc arobas abc point com
 asdf123@abc.com~asdf un deux trois arobas abc point com
 a1b2@abc.com~a un b deux arobas abc point com
 ab3.sdd.3@gmail.com~ab trois point sdd point trois arobas gmail point com
-email is abc1@gmail.com~l'email est abc un arobas gmail point com
-abs@nvidia.com~abs arobas nvidia point com
-email is a-1.b3_c&-d@gma4i-l.com test~l'email est a trait d'union un point b trois underscore c esperluette trait d'union d arobas gma quatre i trait d'union l point com test
-nvidia.com~nvidia point com
+l'email est abc1@gmail.com~l'email est abc un arobas gmail point com
+abs@nvidia.com~abs arobas NVIDIA point com
+l'email est a-1.b3_c&-d@gma4i-l.com test~l'email est a tiret un point b trois tiret bas c esperluette tiret d arobas gma quatre i tiret l point com test
+nvidia.com~NVIDIA point com
 test.com~test point com
-test.abc~test point abc
-http://www.ourdailynews.com.sm~HTTP deux points slash slash double-vé double-vé double-vé point ourdailynews point com point sm
-https://www.ourdailynews.com.sm~HTTPS deux points slash slash double-vé double-vé double-vé point ourdailynews point com point sm
-www.ourdailynews.com.sm~double-vé double-vé double-vé point ourdailynews point com point sm
-www.ourdailynews.com/123-sm~double-vé double-vé double-vé point ourdailynews point com slash un deux trois trait d'union sm
-sdf@gmail.com.sm~sdf arobas gmail point com point sm
-sdf@gmail.com/123-sm~sdf arobas gmail point com slash un deux trois trait d'union sm
-sdf@gmail.abc/123-sm~sdf arobas gmail point abc slash un deux trois trait d'union sm
-sdf@gmail.abc/123456-sm~sdf arobas gmail point abc slash un deux trois quatre cinq six trait d'union sm
-ourdailynews.com/12-sm~ourdailynews point com slash un deux trait d'union sm
-ourdailynews.abc~ourdailynews point abc
-file:///c/code/NeMo/docs/build/html/processing/intro.html~file trois points slash slash slash c slash code slash nemo slash docs slash build slash html slash processing slash intro point html
-file:///photos/image.jpg~file trois points slash slash slash photos slash image point jpg
-electronic test.com and test2.uk~electronic test point com et test deux point uk
-https://developer.nvidia.com/drive-sim-early-access-program~HTTPS deux points slash slash developer point nvidia point com slash drive trait d'union sim trait d'union early trait d'union access trait d'union program
-https://developer.nvidia.com/cv-cuda/early-access~HTTPS deux points slash slash developer point nvidia point com slash cv trait d'union cuda slash early trait d'union access
-https://www.nvidia.com/dgx-basepod~HTTPS deux points slash slash double-vé double-vé double-vé point nvidia point com slash DGX trait d'union basepod
-https://www.nvidia.com/dgx-basepod.sm/3~HTTPS deux points slash slash double-vé double-vé double-vé point nvidia point com slash DGX trait d'union basepod point sm slash trois
-http://www.nvidia.com/rtx-6000~HTTP deux points slash slash double-vé double-vé double-vé point nvidia point com slash RTX trait d'union six mille
-rtxprohelp@exchange.nvidia.com~RTX pro help arobas exchange point nvidia point com
-enterpriseservices@nvidia.com~enterprise services arobas nvidia point com
-enterprise-services@nvidia.com~enterprise trait d'union services arobas nvidia point com
-https://www.nvidia.com/dgx-basepod/~HTTPS deux points slash slash double-vé double-vé double-vé point nvidia point com slash DGX trait d'union basepod slash
+test.abc~test.abc
+http://www.ourdailynews.com.sm~HTTP deux points slash slash double-vé double-vé double-vé point ourdailynews point com point SM
+https://www.ourdailynews.com.sm~HTTPS deux points slash slash double-vé double-vé double-vé point ourdailynews point com point SM
+www.ourdailynews.com.sm~double-vé double-vé double-vé point ourdailynews point com point SM
+www.ourdailynews.com/123-sm~double-vé double-vé double-vé point ourdailynews point com slash un deux trois tiret SM
+sdf@gmail.com.sm~sdf arobas gmail point com point SM
+sdf@gmail.com/123-sm~sdf arobas gmail point com slash un deux trois tiret SM
+sdf@gmail.abc/123-sm~sdf arobas gmail point ABC slash un deux trois tiret SM
+sdf@gmail.abc/123456-sm~sdf arobas gmail point ABC slash un deux trois quatre cinq six tiret SM
+ourdailynews.com/12-sm~ourdailynews point com slash un deux tiret SM
+ourdailynews.abc~ourdailynews.abc
+file:///c/code/NeMo/docs/build/html/processing/intro.html~file deux points slash slash slash c slash code slash nemo slash docs slash build slash html slash processing slash intro point HTML
+file:///photos/image.jpg~file deux points slash slash slash photos slash image point jpeg
+electronic test.com et test2.uk~electronic test point com et test deux point UK
+https://developer.nvidia.com/drive-sim-early-access-program~HTTPS deux points slash slash developer point NVIDIA point com slash drive tiret sim tiret early tiret access tiret program
+https://developer.nvidia.com/cv-cuda/early-access~HTTPS deux points slash slash developer point NVIDIA point com slash cv tiret CUDA slash early tiret access
+https://www.nvidia.com/dgx-basepod~HTTPS deux points slash slash double-vé double-vé double-vé point NVIDIA point com slash DGX tiret BASEPOD
+https://www.nvidia.com/dgx-basepod.sm/3~HTTPS deux points slash slash double-vé double-vé double-vé point NVIDIA point com slash DGX tiret BASEPOD point SM slash trois
+http://www.nvidia.com/rtx-6000~HTTP deux points slash slash double-vé double-vé double-vé point NVIDIA point com slash RTX tiret six mille
+rtxprohelp@exchange.nvidia.com~RTX pro help arobas exchange point NVIDIA point com
+enterpriseservices@nvidia.com~enterprise services arobas NVIDIA point com
+enterprise-services@nvidia.com~enterprise tiret services arobas NVIDIA point com
+https://www.nvidia.com/dgx-basepod/~HTTPS deux points slash slash double-vé double-vé double-vé point NVIDIA point com slash DGX tiret BASEPOD slash

--- a/tests/nemo_text_processing/fr/test_electronic.py
+++ b/tests/nemo_text_processing/fr/test_electronic.py
@@ -16,16 +16,27 @@ import pytest
 from parameterized import parameterized
 
 from nemo_text_processing.inverse_text_normalization.inverse_normalize import InverseNormalizer
+from nemo_text_processing.text_normalization.normalize import Normalizer
 
 from ..utils import CACHE_DIR, parse_test_case_file
 
 
 class TestElectronic:
     inverse_normalizer = InverseNormalizer(lang='fr', cache_dir=CACHE_DIR, overwrite_cache=False)
+    
 
     @parameterized.expand(parse_test_case_file('fr/data_inverse_text_normalization/test_cases_electronic.txt'))
     @pytest.mark.run_only_on('CPU')
     @pytest.mark.unit
     def test_denorm(self, test_input, expected):
         pred = self.inverse_normalizer.inverse_normalize(test_input, verbose=False)
+        assert pred == expected
+
+    normalizer = Normalizer(input_case='cased', lang='fr', cache_dir=CACHE_DIR, overwrite_cache=False)
+
+    @parameterized.expand(parse_test_case_file('fr/data_text_normalization/test_cases_electronic.txt'))
+    @pytest.mark.run_only_on('CPU')
+    @pytest.mark.unit
+    def test_norm(self, test_input, expected):
+        pred = self.normalizer.normalize(test_input, verbose=False)
         assert pred == expected


### PR DESCRIPTION
Adds handling for French electronics like;
- URLs
- Emails

Largely that means, handling:
: - `deux points`
. - `point`
www - `double-vé double-vé double-vé`

Many symbols
---
/	slash
\-	tiret
_	tiret bas
!	point d'exclamation
\#	dièse
$	dollar
%	pour cent
&	esperluette
'	apostrophe
\*	astérisque
\+	plus
=	égal
?	point d'interrogation
^	accent circumflex
`	accent grave
|	barre verticale
~	tilde
,	virgule
